### PR TITLE
Correct codemirror parsing for colon.

### DIFF
--- a/codemirror/julia.js
+++ b/codemirror/julia.js
@@ -34,7 +34,7 @@ CodeMirror.defineMode("julia2", function(config, parserConfig) {
     return new RegExp("^(" + words.join("|") + ")\\b");
   }
 
-  var binary_operatos = /^(?:&&|\|\||::|==|!=|=|[<>]=?|\?|\:|[*\/\+-]=?|[≤≥=&\|])/
+  var binary_operatos = /^(?:&&|\|\||::|<:|==|!=|=|[<>]=?|\?|\:|[*\/\+-]=?|[≤≥=&\|])/
   var operators   = /^(?:\.?[|&^\\%*+\-<>!=\/]=?|\?|~|::|:|\$|<:|\.[<>]|<<=?|>>>?=?|\.[<>=]=|->?|\/\/|\bin\b|\.{3}|\.)/;
   var delimiters  = /^[;,()[\]{}]/;
   var identifiers = /^[_A-Za-z][_A-Za-z0-9!]*/;


### PR DESCRIPTION
Hi,

This is a very basic (I don't do much javascript) attempt to make highlighting of colons work correctly.

Prior to this colon characters in ranges and type assertions would be parsed as symbols along with the next word. From my initial tests this change seems to solve this problem, although there may be a better way to do this.

You can see an example of the incorrect highlighting in the screenshot for Jupiter. The variable in the range expression is highlighted as a symbol.
