### PR TITLE
Fixes issue where module name in status bar is not set correctly

### DIFF
--- a/jewel.behaviors
+++ b/jewel.behaviors
@@ -9,7 +9,7 @@
                                           :mime "text/julia"
                                           :tags [:editor.julia]}])]
 
-     :editor [:lt.objs.langs.julia.module/update-module-statusbar]
+     :editor.active [:lt.objs.langs.julia.module/update-module-statusbar]
 
      :editor.julia [:lt.objs.langs.julia.proc/connect-on-open
                     :lt.objs.langs.julia.proc/attach-on-connect

--- a/src/julia/module.cljs
+++ b/src/julia/module.cljs
@@ -25,15 +25,10 @@
 (defn ->module [editor]
   (::module @editor))
 
-(defn isactive? [editor]
-  (identical? (lt.objs.editor.pool/last-active) editor))
-
-
 (behavior ::update-module-statusbar
           :triggers #{:active :module-update}
           :reaction (fn [editor]
-                      (if (isactive? editor)
-                        (object/merge! statusbar-module {:module (->module editor)}))))
+                      (object/merge! statusbar-module {:module (->module editor)})))
 
 ;; Backend communication
 


### PR DESCRIPTION
Steps to reproduce the issue this PR fixes:

1) disable :lt.objs.langs.julia/connect-on-open in user.behaviors
2) close and reopen LT
3) open two julia files
4) go to the first one opened (left most tab)
5) eval something in it

Expected behaviour:  Module of the current file is shown in the status bar
Actual behaviour:  Module of the other file is shown in the status bar

The fix just ensures the `behavior` that sets the module in the status bar, only updates it for the currently active editor.
