### PR TITLE
add support for underscores in number

### DIFF
--- a/codemirror/julia.js
+++ b/codemirror/julia.js
@@ -273,7 +273,7 @@ CodeMirror.defineMode("julia2", function(config, parserConfig) {
     }
 
     // Number Literals
-    if (stream.match(/[+-]?([0-9]+\.|\.[0-9]+|[0-9]+)[0-9]*([ef][+-]?[0-9]+)?(im)?/i)) {
+    if (stream.match(/[+-]?([0-9_]+\.|\.[0-9]+|[0-9_]+)[0-9]*([ef][+-]?[0-9]+)?(im)?/i)) {
       finalise_leavingexpr(state, stream);
       return 'number';
     }


### PR DESCRIPTION
Something that'd be nice is if I could a regex like `[0-9]+(_[0-9]{3})+`
to work with the current implementation, because that would provide
extra error checking (whether the `_` are in the right place or not).
