### PR TITLE
Fix incorrect highlighting as float.

### DIFF
--- a/js/julia.js
+++ b/js/julia.js
@@ -176,7 +176,7 @@ CodeMirror.defineMode("julia2", function(config, parserConfig) {
 
       if (stream.match(/^[\d_]+\.[\d_]*([Eef][+-]?\d+)?/)) {
         float_literal = true;
-      } else if (stream.match(/^[\d_]*\.[\d_]+([Eef][+-]?\d+)?/)) {
+      } else if (stream.match(/^[\d_]*\.(?![_])[\d_]+([Eef][+-]?\d+)?/)) {
         float_literal = true;
       }
 


### PR DESCRIPTION
Previously `Foo._bar` would highlight `._` as a number.

@one-more-minute sorry about missing this one. Only just noticed it this evening.