### PR TITLE
Workaround JuliaLang/julia#6765

### DIFF
--- a/jl/init.jl
+++ b/jl/init.jl
@@ -28,6 +28,9 @@ catch e
   end
 end
 
+# workaround JuliaLang/julia#6765
+eval(Base, :(is_interactive = true))
+
 require("Jewel")
 
 Jewel.server(map(parseint, ARGS)..., true)


### PR DESCRIPTION
I needed this workaround in order to use Gtk.jl with Juno. It's the same workaround that @stevengj wrote for IJulia to fix [JuliaLang/#6765](https://github.com/JuliaLang/julia/issues/6765).